### PR TITLE
fix(openproject): serialize attachment metadata correctly

### DIFF
--- a/src/openproject.ts
+++ b/src/openproject.ts
@@ -219,7 +219,7 @@ export class OpenProjectClient {
 			const { fileName } = attachment;
 			if (existingNames.has(fileName)) continue;
 			const form = new FormData();
-			form.append("metadata", new Blob([JSON.stringify({ fileName })], { type: "application/json" }));
+			form.append("metadata", JSON.stringify({ fileName }));
 			form.append("file", new Blob([Uint8Array.from(attachment.bytes)], { type: attachment.detectedContentType }), fileName);
 			try {
 				await this.request<Attachment>(`${containerPath}/attachments`, { method: "POST", body: form });

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -523,8 +523,12 @@ test("OpenProject creation uploads Discord images and embeds native attachment r
 		assert.equal(creationPayload.description.raw.includes("cdn.discordapp.com"), false);
 		const upload = calls.find(call => call.init.body instanceof FormData);
 		assert.ok(upload);
-		assert.equal(JSON.parse(await upload.init.body.get("metadata").text()).fileName, "a1-schema.png");
+		assert.equal(JSON.parse(upload.init.body.get("metadata")).fileName, "a1-schema.png");
 		assert.equal(upload.init.body.get("file").type, "image/png");
+		const multipart = await new Request("https://project.example/upload", { method: "POST", body: upload.init.body }).text();
+		assert.match(multipart, /name="metadata"\r\n\r\n\{"fileName":"a1-schema\.png"\}/);
+		assert.doesNotMatch(multipart, /name="metadata"; filename=/);
+		assert.match(multipart, /name="file"; filename="a1-schema\.png"/);
 	} finally {
 		globalThis.fetch = originalFetch;
 	}


### PR DESCRIPTION
## Summary
- serialize attachment metadata as a plain multipart field instead of a file-like Blob
- prevent OpenProject from parsing metadata as an ActiveSupport hash
- assert the raw multipart wire format has no filename on metadata

## Verification
- npm test (200 tests)