### PR TITLE
fix(tasks): restore images during reconciliation

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -1205,6 +1205,17 @@ export class Database {
 		);
 	}
 
+	async reconciliationAttachments(id: string) {
+		const result = await this.pool.query<{ attachments: OpenProjectAttachmentInput[] }>(
+			`SELECT source_attachments AS attachments FROM task_proposals WHERE id=$1 AND status='needs_reconciliation'
+			 UNION ALL
+			 SELECT COALESCE(payload->'sourceAttachments','[]'::jsonb) AS attachments FROM task_drafts WHERE id=$1 AND status='needs_reconciliation'
+			 LIMIT 1`,
+			[id],
+		);
+		return result.rows[0]?.attachments ?? [];
+	}
+
 	async reconcileCreation(id: string, actorId: string, workPackageId: number) {
 		const client = await this.pool.connect();
 		try {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -983,15 +983,18 @@ async function handleSlash(interaction: ChatInputCommandInteraction, services: S
 	await interaction.deferReply({ ephemeral: true });
 	if (subcommand === "reconcile") {
 		requireOrganizer(interaction, services);
+		const reconciliationId = interaction.options.getString("proposal", true);
 		const workPackageId = interaction.options.getInteger("work_package_id", true);
 		const workPackage = await services.openProject.workPackage(workPackageId);
 		await requireProjectAccess(interaction, projectIdFromWorkPackage(workPackage), services);
+		const attachments = await services.db.reconciliationAttachments(reconciliationId);
+		if (attachments.length) await services.openProject.attachWorkPackageImages(workPackageId, attachments);
 		await services.db.reconcileCreation(
-			interaction.options.getString("proposal", true),
+			reconciliationId,
 			interaction.user.id,
 			workPackageId,
 		);
-		await interaction.editReply("Creation reconciled; no second OpenProject task was created.");
+		await interaction.editReply(`Creation reconciled${attachments.length ? " and its missing images were uploaded" : ""}; no second OpenProject task was created.`);
 		return;
 	}
 	if (subcommand === "metrics") {

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -111,6 +111,19 @@ test("manual ambiguous drafts can be reconciled transactionally", async () => {
 	assert.equal(queries.some(({ sql }) => sql.includes("openproject_work_package_id,event")), true);
 });
 
+test("reconciliation loads pending proposal images before finalizing", async () => {
+	let query;
+	const attachments = [{ id: "image", name: "banner.png", contentType: "image/png", url: "https://cdn.discordapp.com/banner.png" }];
+	const db = databaseWithPool({ async query(sql, values) {
+		query = { sql, values };
+		return { rowCount: 1, rows: [{ attachments }] };
+	} });
+	assert.deepEqual(await db.reconciliationAttachments("proposal"), attachments);
+	assert.match(query.sql, /source_attachments AS attachments/);
+	assert.match(query.sql, /payload->'sourceAttachments'/);
+	assert.deepEqual(query.values, ["proposal"]);
+});
+
 test("AI proposal metadata is persisted for reviewed task creation", async () => {
 	let inserted;
 	const db = databaseWithPool({


### PR DESCRIPTION
## Summary
- load retained proposal or draft attachments during ambiguous-creation reconciliation
- upload missing images to the confirmed OpenProject work package before finalizing state
- report successful image restoration to the organizer

## Verification
- npm test (202 tests)