### PR TITLE
fix(ai): reduce provider rate pressure

### DIFF
--- a/src/automatic-tasks.ts
+++ b/src/automatic-tasks.ts
@@ -1,5 +1,5 @@
 import { Client, Message, PermissionFlagsBits, type MessageCreateOptions } from "discord.js";
-import { automaticCandidateEligible, containsSensitiveContent, extractionDiagnostics, mergeRelatedTaskCandidates, minimizeText, SensitiveContentError, StructuredOutputError, type ContextSelectionResult, type MinimizedMessage, type ProposalReconciliationResult, type TaskExtractor } from "./azure-openai.js";
+import { automaticCandidateEligible, containsSensitiveContent, extractionDiagnostics, mergeRelatedTaskCandidates, minimizeText, SensitiveContentError, shouldReconcileTaskProposals, shouldSelectTaskContext, StructuredOutputError, type ContextSelectionResult, type MinimizedMessage, type ProposalReconciliationResult, type TaskExtractor } from "./azure-openai.js";
 import { isOrganizerGuild, type IntegrationConfig } from "./config.js";
 import { Database } from "./database.js";
 import { OpenProjectClient, titlesLikelyDuplicate, workPackageMarkdownLink } from "./openproject.js";
@@ -227,10 +227,12 @@ export function registerAutomaticTaskDetection(client: Client, services: Automat
 				...window.messages.map(message => message.id),
 				...minimizedCandidates.filter(message => message.contextRole === "reply_target" || message.contextRole === "thread_root").map(message => message.id),
 			]);
+			const needsContextSelection = shouldSelectTaskContext(minimizedCandidates.length);
 			let contextSelection: ContextSelectionResult = {
-				messages: minimizedCandidates.filter(message => fallbackIds.has(message.id)), deployment: "deterministic", latencyMs: 0,
+				messages: needsContextSelection ? minimizedCandidates.filter(message => fallbackIds.has(message.id)) : minimizedCandidates,
+				deployment: "deterministic", latencyMs: 0,
 			};
-			if (services.extractor.selectContext) try {
+			if (services.extractor.selectContext && needsContextSelection) try {
 				contextSelection = await services.extractor.selectContext(minimizedCandidates, [primary.id]);
 			} catch (error) {
 				console.warn("Automatic AI context selection failed; using the bounded collected graph", { error: (error as Error).message });
@@ -278,7 +280,7 @@ export function registerAutomaticTaskDetection(client: Client, services: Automat
 				supersededPendingProposalIds: [], deployment: "deterministic", latencyMs: 0,
 			};
 			let reconciliationSucceeded = false;
-			if (services.extractor.reconcileProposals) try {
+			if (services.extractor.reconcileProposals && shouldReconcileTaskProposals(groupedTasks.length, pendingProposals.length)) try {
 				reconciliation = await services.extractor.reconcileProposals(extraction.inputMessages, groupedTasks, pendingProposals, affectedPendingProposalIds);
 				reconciliationSucceeded = true;
 			} catch (error) {

--- a/src/azure-openai.ts
+++ b/src/azure-openai.ts
@@ -196,6 +196,14 @@ export function automaticCandidateEligible(assessment?: AutomaticCandidateAssess
 		&& assessment.sensitivity === "safe");
 }
 
+export function shouldSelectTaskContext(messageCount: number) {
+	return messageCount > 24;
+}
+
+export function shouldReconcileTaskProposals(candidateCount: number, pendingProposalCount: number) {
+	return candidateCount > 1 || (candidateCount > 0 && pendingProposalCount > 0);
+}
+
 export function mergeRelatedTaskCandidates(tasks: ExtractedTask[]) {
 	const grouped: ExtractedTask[] = [];
 	const compatibleValue = (left: unknown, right: unknown) => left == null || right == null || left === right;
@@ -541,6 +549,43 @@ function addDeterministicAmbiguities(extraction: ExtractionResult, messages: Min
 	return extraction;
 }
 
+function providerRetryDelayMs(response: Response, attempt: number) {
+	const retryAfterMsHeader = response.headers.get("retry-after-ms") ?? response.headers.get("x-ms-retry-after-ms");
+	if (retryAfterMsHeader !== null) {
+		const retryAfterMs = Number(retryAfterMsHeader);
+		if (Number.isFinite(retryAfterMs)) return Math.min(30_000, Math.max(0, retryAfterMs));
+	}
+	const retryAfter = response.headers.get("retry-after");
+	if (retryAfter !== null) {
+		const seconds = Number(retryAfter);
+		if (Number.isFinite(seconds)) return Math.min(30_000, Math.max(0, seconds * 1000));
+		const date = Date.parse(retryAfter);
+		if (Number.isFinite(date)) return Math.min(30_000, Math.max(0, date - Date.now()));
+	}
+	return 5000 * (attempt + 1);
+}
+
+async function fetchProviderWithRetry(url: string, init: RequestInit, attempts = 3) {
+	for (let attempt = 0; ; attempt++) {
+		const response = await fetch(url, init);
+		const retryable = response.status === 429 || response.status === 500 || response.status === 502 || response.status === 503 || response.status === 504;
+		if (!retryable || attempt + 1 >= attempts) return response;
+		await response.body?.cancel().catch(() => undefined);
+		await new Promise<void>((resolve, reject) => {
+			const onAbort = () => {
+				clearTimeout(timer);
+				reject(init.signal?.reason ?? new Error("Provider request aborted."));
+			};
+			const timer = setTimeout(() => {
+				init.signal?.removeEventListener("abort", onAbort);
+				resolve();
+			}, providerRetryDelayMs(response, attempt));
+			if (init.signal?.aborted) onAbort();
+			else init.signal?.addEventListener("abort", onAbort, { once: true });
+		});
+	}
+}
+
 async function invokeContextSelectionCompatible(options: {
 	url: string;
 	model: string;
@@ -554,7 +599,7 @@ async function invokeContextSelectionCompatible(options: {
 	const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 120000);
 	try {
 		const started = Date.now();
-		const response = await fetch(options.url, {
+		const response = await fetchProviderWithRetry(options.url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: { ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}), "Content-Type": "application/json" },
@@ -611,7 +656,7 @@ async function invokeProposalReconciliationCompatible(options: {
 	const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 120000);
 	try {
 		const started = Date.now();
-		const response = await fetch(options.url, {
+		const response = await fetchProviderWithRetry(options.url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: { ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}), "Content-Type": "application/json" },
@@ -695,7 +740,7 @@ async function invokeCompatible(options: {
 			{ type: "text", text: JSON.stringify(selectedMessages) },
 			...imageParts,
 		];
-		const response = await fetch(options.url, {
+		const response = await fetchProviderWithRetry(options.url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: {
@@ -776,7 +821,7 @@ async function invokeAutomaticGateCompatible(options: {
 			proposedAction: candidate.proposed_action,
 			sourceMessageIds: candidate.source_message_ids,
 		}));
-		const response = await fetch(options.url, {
+		const response = await fetchProviderWithRetry(options.url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: {
@@ -829,7 +874,7 @@ async function invokeRagRerankerCompatible(options: {
 	const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 120000);
 	try {
 		const started = Date.now();
-		const response = await fetch(options.url, {
+		const response = await fetchProviderWithRetry(options.url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -30,7 +30,7 @@ import { randomUUID } from "node:crypto";
 import { isOrganizerGuild, type IntegrationConfig, type TeamMapping } from "./config.js";
 import { correctionFields, Database, proposalDismissalReasons, type CorrectionFlags, type ProposalDismissalReason, type ProposalMetrics, type ProposalRagCandidate } from "./database.js";
 import { OpenProjectClient, OpenProjectRequestError, openProjectAttachmentFileName, workPackageChangesApplied, workPackageMarkdownLink, type OpenProjectAttachmentInput } from "./openproject.js";
-import { attachExtractionDiagnostics, automaticCandidateEligible, containsSensitiveContent, extractionDiagnostics, mergeRelatedTaskCandidates, minimizeText, normalizeExtractedDate, sanitizeGeneratedDescription, SensitiveContentError, StructuredOutputError, type ContextSelectionResult, type ExtractedTasks, type ExtractionResult, type MinimizedMessage, type ProposalReconciliationResult, type TaskExtractor } from "./azure-openai.js";
+import { attachExtractionDiagnostics, automaticCandidateEligible, containsSensitiveContent, extractionDiagnostics, mergeRelatedTaskCandidates, minimizeText, normalizeExtractedDate, sanitizeGeneratedDescription, SensitiveContentError, shouldReconcileTaskProposals, shouldSelectTaskContext, StructuredOutputError, type ContextSelectionResult, type ExtractedTasks, type ExtractionResult, type MinimizedMessage, type ProposalReconciliationResult, type TaskExtractor } from "./azure-openai.js";
 import { resolveProposalTarget, type OpenProjectRag } from "./rag.js";
 import { composeOpenProjectMarkdown, describeProposalOperations, formatGeneratedTaskDescription, formatProposalContent, planExistingTaskOperations, sourceContentHash, taskReferencesAreValid, type MetadataFieldName, type ProposalMetadataPatch } from "./task-proposals.js";
 import { isExcludedChannel, projectIdForName, projectIdForProposedOwner, projectIdForTeamRoles, projectIdFromChannelNames, resolveProjectId } from "./project-resolution.js";
@@ -1608,7 +1608,7 @@ async function completeAiContext(
 	const priorities = await services.openProject.priorities();
 	const tentativeSizes = tentativeProjectId ? await services.openProject.sizeOptions(tentativeProjectId) : [];
 	let contextSelection: ContextSelectionResult = { messages: context.messages, deployment: "deterministic", latencyMs: 0 };
-	if (services.extractor.selectContext) try {
+	if (services.extractor.selectContext && shouldSelectTaskContext(context.messages.length)) try {
 		contextSelection = await services.extractor.selectContext(context.messages, [...context.focusIds]);
 	} catch (error) {
 		console.warn("AI context selection failed; using the bounded collected graph", { error: (error as Error).message });
@@ -1635,7 +1635,7 @@ async function completeAiContext(
 		proposals: groupedCandidates.map(candidate => ({ candidate })),
 		supersededPendingProposalIds: [], deployment: "deterministic", latencyMs: 0,
 	};
-	if (services.extractor.reconcileProposals) try {
+	if (services.extractor.reconcileProposals && shouldReconcileTaskProposals(groupedCandidates.length, pendingProposals.length)) try {
 		reconciliation = await services.extractor.reconcileProposals(extraction.inputMessages, groupedCandidates, pendingProposals);
 	} catch (error) {
 		console.warn("AI proposal reconciliation failed; using grounded candidates", { error: (error as Error).message });

--- a/test/azure-openai.test.js
+++ b/test/azure-openai.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { automaticCandidateEligible, AzureTaskExtractor, containsSensitiveContent, mergeRelatedTaskCandidates, minimizeText, normalizeExtractedDate, sensitiveContentReasons } from "../dist/azure-openai.js";
+import { automaticCandidateEligible, AzureTaskExtractor, containsSensitiveContent, mergeRelatedTaskCandidates, minimizeText, normalizeExtractedDate, sensitiveContentReasons, shouldReconcileTaskProposals, shouldSelectTaskContext } from "../dist/azure-openai.js";
 
 test("minimizeText removes common credentials and personal contact data", () => {
 	const value = minimizeText(
@@ -24,6 +24,15 @@ test("extracted dates are normalized or discarded before review", () => {
 	assert.equal(normalizeExtractedDate("2026-07-28T12:30:00Z"), "2026-07-28");
 	assert.equal(normalizeExtractedDate("2026-02-30"), null);
 	assert.equal(normalizeExtractedDate("07/28/2026"), null);
+});
+
+test("auxiliary AI stages run only when they add material value", () => {
+	assert.equal(shouldSelectTaskContext(24), false);
+	assert.equal(shouldSelectTaskContext(25), true);
+	assert.equal(shouldReconcileTaskProposals(1, 0), false);
+	assert.equal(shouldReconcileTaskProposals(2, 0), true);
+	assert.equal(shouldReconcileTaskProposals(1, 1), true);
+	assert.equal(shouldReconcileTaskProposals(0, 1), false);
 });
 
 const config = {
@@ -91,6 +100,45 @@ test("Azure extractor authenticates, bounds output, and uses the configured depl
 			timestamp: "2026-07-13T00:00:00Z", contextRole: "primary",
 		}]);
 		assert.deepEqual(extraction.metadata, { priorities: ["High"], sizes: ["Small"], projects: ["Communications Team"] });
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("Azure extractor retries transient rate limits using provider guidance", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = async () => {
+		calls++;
+		if (calls === 1) return Response.json({ error: { message: "rate limited" } }, { status: 429, headers: { "retry-after-ms": "0" } });
+		return Response.json({ choices: [{ message: { content: JSON.stringify({ tasks: [], ambiguities: [] }) } }] });
+	};
+	try {
+		const result = await new AzureTaskExtractor(config, async () => "token").extract([
+			{ id: "m1", authorAlias: "USER_1", text: "Ship it", timestamp: "2026-07-13T00:00:00Z", contextRole: "primary" },
+		]);
+		assert.equal(calls, 2);
+		assert.deepEqual(result.result.tasks, []);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("Azure extractor bounds persistent rate-limit retries", async () => {
+	const originalFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = async () => {
+		calls++;
+		return Response.json({ error: { message: "rate limited" } }, { status: 429, headers: { "retry-after-ms": "0" } });
+	};
+	try {
+		await assert.rejects(
+			new AzureTaskExtractor(config, async () => "token").extract([
+				{ id: "m1", authorAlias: "USER_1", text: "Ship it", timestamp: "2026-07-13T00:00:00Z", contextRole: "primary" },
+			]),
+			/429/,
+		);
+		assert.equal(calls, 3);
 	} finally {
 		globalThis.fetch = originalFetch;
 	}


### PR DESCRIPTION
## Summary
- skip semantic context selection for bounded graphs while retaining all collected context
- skip proposal reconciliation when there is only one candidate and no pending proposal
- retry Azure 429 and transient 5xx responses with bounded provider-directed backoff

## Validation
- npm test (205 passed)
- docker build -t track-the-hack-bot:rate-limit-test .
- npm audit --omit=dev --audit-level=high
- git diff --check