### PR TITLE
feat(ai): queue incorrect corpus cases

### DIFF
--- a/corpus-ui/src/App.tsx
+++ b/corpus-ui/src/App.tsx
@@ -197,7 +197,7 @@ export default function App() {
 				<Queue cases={cases} activeId={selectedId} status={status} query={query} loading={loading} onStatus={setStatus} onQuery={setQuery} onSelect={selectCase} />
 				{draft ? <>
 					<div className="case-main" aria-busy={busy}>
-						<div className="case-title"><div><span className={`status-chip ${draft.adjudication.status}`}>{draft.adjudication.status}</span><h2 ref={caseHeading} tabIndex={-1}>{draft.id}</h2><p>{draft.origin.type} origin · {draft.window.mode} mode · updated {formatDate(draft.updatedAt)}{dirty ? " · unsaved changes" : ""}</p></div><div className="case-mark">#{draft.schemaVersion}</div></div>
+						<div className="case-title"><div><span className={`status-chip ${draft.adjudication.status}`}>{draft.adjudication.status}</span>{draft.origin.reviewKind === "incorrect_proposal" ? <span className="correction-marker">Correction needed: replace or remove the rejected output</span> : null}<h2 ref={caseHeading} tabIndex={-1}>{draft.id}</h2><p>{draft.origin.type} origin · {draft.window.mode} mode · updated {formatDate(draft.updatedAt)}{dirty ? " · unsaved changes" : ""}</p></div><div className="case-mark">#{draft.schemaVersion}</div></div>
 						<Timeline messages={draft.window.messages} discordMessages={draft.reviewContext?.discordMessages} invalidEvidence={invalidFields.some(field => field.startsWith("role-"))} onRecoverContext={openRecovery} onChange={messages => {
 							const next = { ...draft, window: { ...draft.window, messages } };
 							if (invalidFields.length) setInvalidFields(validate(next).flatMap(error => error.field ? [error.field] : []));

--- a/corpus-ui/src/components/ProposalEditor.tsx
+++ b/corpus-ui/src/components/ProposalEditor.tsx
@@ -7,7 +7,7 @@ interface ProposalEditorProps {
 	onChange: (proposals: ExpectedProposal[]) => void;
 }
 
-const emptyProposal = (): ExpectedProposal => ({ action: "create", titleIncludes: [], sourceMessageIds: [], assigneeAlias: null, dueDate: null });
+const emptyProposal = (): ExpectedProposal => ({ action: "create", titleIncludes: [], sourceMessageIds: [], projectName: null, assigneeAlias: null, dueDate: null });
 
 export function ProposalEditor({ proposals, messages, invalidFields, onChange }: ProposalEditorProps) {
 	function patch(index: number, value: Partial<ExpectedProposal>) {
@@ -29,6 +29,7 @@ export function ProposalEditor({ proposals, messages, invalidFields, onChange }:
 				</div>
 				<label>Title must include<input id={`proposal-title-${index}`} value={proposal.titleIncludes.join(", ")} onChange={event => patch(index, { titleIncludes: event.target.value.split(",").map(value => value.trim()) })} onBlur={() => patch(index, { titleIncludes: proposal.titleIncludes.filter(Boolean) })} placeholder="sponsor, outreach, deck" aria-invalid={invalidFields.includes(`proposal-title-${index}`)} aria-describedby={`title-help-${index}`} /></label>
 				<span className="field-help" id={`title-help-${index}`}>{invalidFields.includes(`proposal-title-${index}`) ? "Enter at least one matching term." : "Comma-separated matching terms."}</span>
+				<label>Project name<input value={proposal.projectName ?? ""} onChange={event => patch(index, { projectName: event.target.value || null })} placeholder="Optional project" /></label>
 				<label>Due date<input type="date" value={proposal.dueDate ?? ""} onChange={event => patch(index, { dueDate: event.target.value || null })} /></label>
 				<div className="source-picker" id={`proposal-source-${index}`} tabIndex={-1} aria-invalid={invalidFields.includes(`proposal-source-${index}`)} aria-describedby={invalidFields.includes(`proposal-source-${index}`) ? `source-error-${index}` : undefined}>
 					<span className="field-label">Source messages</span>

--- a/corpus-ui/src/components/Queue.tsx
+++ b/corpus-ui/src/components/Queue.tsx
@@ -38,6 +38,7 @@ export function Queue({ cases, activeId, status, query, loading, onStatus, onQue
 				const messageCount = item.messageCount ?? item.window?.messages?.length;
 				return <button type="button" className={`queue-item ${activeId === item.id ? "selected" : ""}`} key={item.id} onClick={() => onSelect(item.id)} aria-current={activeId === item.id ? "true" : undefined}>
 					<span className="queue-item-top"><strong>{item.id}</strong><span className={`status-dot ${itemStatus}`}>{itemStatus}</span></span>
+					{item.reviewKind === "incorrect_proposal" ? <span className="correction-marker">Correction needed</span> : null}
 					<span className="queue-meta"><span>{origin}</span><span>{mode ?? "unassigned"}</span>{messageCount !== undefined ? <span>{messageCount} msg</span> : null}</span>
 				</button>;
 			})}

--- a/corpus-ui/src/styles.css
+++ b/corpus-ui/src/styles.css
@@ -184,6 +184,7 @@ textarea { min-height: 96px; line-height: 1.5; resize: vertical; }
 .queue-meta { justify-content: flex-start; margin-top: 10px; color: #704b45; font-size: 11px; }
 .queue-meta span + span::before { margin-right: 6px; content: "·"; }
 .status-dot, .status-chip { display: inline-flex; align-items: center; gap: 5px; font-weight: 600; text-transform: capitalize; }
+.correction-marker { display: inline-flex; width: fit-content; margin: 7px 0 0; padding: 3px 7px; color: var(--error); background: #f9d3c4; border: 1px solid currentColor; border-radius: 5px; font-size: 10px; font-weight: 700; }
 .status-dot { font-size: 10px; }
 .status-dot::before { width: 8px; height: 8px; background: var(--warning); border-radius: 50%; content: ""; }
 .status-dot.included::before { background: var(--success); }

--- a/corpus-ui/src/types.ts
+++ b/corpus-ui/src/types.ts
@@ -26,7 +26,7 @@ export interface ExpectedProposal {
 export interface CorpusCase {
 	schemaVersion: "v2";
 	id: string;
-	origin: { type: "reviewed_proposal" | "sampled_no_task" | "manual_scenario"; [key: string]: unknown };
+	origin: { type: "reviewed_proposal" | "sampled_no_task" | "manual_scenario"; reviewKind?: "incorrect_proposal"; reviewFingerprint?: string; [key: string]: unknown };
 	window: {
 		id: string;
 		mode: "manual" | "automatic";
@@ -66,6 +66,7 @@ export interface CaseSummary {
 	id: string;
 	status?: ReviewStatus;
 	originType?: string;
+	reviewKind?: "incorrect_proposal";
 	mode?: "manual" | "automatic";
 	messageCount?: number;
 	proposalCount?: number;

--- a/docs/ai-evaluation.md
+++ b/docs/ai-evaluation.md
@@ -35,7 +35,10 @@ The canonical corpus is stored as independently versioned case documents under
 `cases/` in the private `ai-evaluation` Blob container. The production sync job
 adds safe review-derived and sampled `no_task` cases as `pending`; it never
 admits a sampled negative without an explicit safe whole-window assessment.
-Review-derived windows retain only candidate source/support messages. Source
+Normal review-derived windows retain only candidate source/support messages.
+Incorrect-proposal dismissals are sync-only pending correction cases that retain
+the full safe bounded snapshot and seed the rejected output for editing. They
+cannot be included until that expected output is changed or removed. Source
 changes preserve notes but reset the case to `pending`; sensitive blocks,
 sensitive overrides, and unsafe input are not synchronized.
 

--- a/src/ai-corpus-blob.ts
+++ b/src/ai-corpus-blob.ts
@@ -7,6 +7,7 @@ export type CorpusCaseSummary = {
 	id: string;
 	status: CorpusCase["adjudication"]["status"];
 	originType: CorpusCase["origin"]["type"];
+	reviewKind?: CorpusCase["origin"]["reviewKind"];
 	updatedAt: string;
 	messageCount: number;
 	proposalCount: number;
@@ -102,6 +103,7 @@ export class AzureBlobCorpusStore implements CorpusStore {
 		return {
 			status: value.adjudication.status,
 			origin: value.origin.type,
+			...(value.origin.reviewKind ? { reviewkind: value.origin.reviewKind } : {}),
 			updated: value.updatedAt,
 			messages: String(value.window.messages.length),
 			proposals: String(value.window.expected.proposals.length),
@@ -119,6 +121,7 @@ export class AzureBlobCorpusStore implements CorpusStore {
 					id,
 					status: zStatus(item.metadata.status),
 					originType: zOrigin(item.metadata.origin),
+					reviewKind: zReviewKind(item.metadata.reviewkind),
 					updatedAt: item.metadata.updated,
 					messageCount: Number(item.metadata.messages ?? 0),
 					proposalCount: Number(item.metadata.proposals ?? 0),
@@ -132,6 +135,7 @@ export class AzureBlobCorpusStore implements CorpusStore {
 				id: value.id,
 				status: value.adjudication.status,
 				originType: value.origin.type,
+				reviewKind: value.origin.reviewKind,
 				updatedAt: value.updatedAt,
 				messageCount: value.window.messages.length,
 				proposalCount: value.window.expected.proposals.length,
@@ -269,4 +273,9 @@ function zStatus(value: string): CorpusCase["adjudication"]["status"] {
 function zOrigin(value: string): CorpusCase["origin"]["type"] {
 	if (value === "reviewed_proposal" || value === "sampled_no_task" || value === "manual_scenario") return value;
 	throw new Error("Corpus blob has invalid origin metadata.");
+}
+
+function zReviewKind(value: string | undefined): CorpusCase["origin"]["reviewKind"] {
+	if (value === undefined || value === "incorrect_proposal") return value;
+	throw new Error("Corpus blob has invalid review kind metadata.");
 }

--- a/src/ai-corpus-server.ts
+++ b/src/ai-corpus-server.ts
@@ -66,7 +66,7 @@ export function createCorpusApp(options: {
 		try {
 			const status = z.enum(["pending", "included", "excluded"]).optional().parse(request.query.status);
 			const query = typeof request.query.query === "string" ? request.query.query.toLocaleLowerCase().trim() : "";
-			const cases = (await options.store.listCases()).filter(item => (!status || item.status === status) && (!query || `${item.id}\n${item.preview}`.toLocaleLowerCase().includes(query)));
+			const cases = (await options.store.listCases()).filter(item => (!status || item.status === status) && (!query || `${item.id}\n${item.originType}\n${item.reviewKind ?? ""}\n${item.preview}`.toLocaleLowerCase().includes(query)));
 			response.json({ cases });
 		} catch (error) { next(error); }
 	});

--- a/src/ai-corpus.ts
+++ b/src/ai-corpus.ts
@@ -84,6 +84,8 @@ export const corpusCaseSchema = z.object({
 		type: z.enum(["reviewed_proposal", "sampled_no_task", "manual_scenario"]),
 		extractionEventId: z.string().optional(),
 		fingerprint: z.string().optional(),
+		reviewKind: z.literal("incorrect_proposal").optional(),
+		reviewFingerprint: z.string().length(64).regex(/^[a-f0-9]+$/).optional(),
 	}),
 	window: corpusWindowSchema,
 	reviewContext: z.object({
@@ -104,6 +106,15 @@ export const corpusCaseSchema = z.object({
 	createdAt: z.iso.datetime(),
 	updatedAt: z.iso.datetime(),
 }).superRefine((value, context) => {
+	if (Boolean(value.origin.reviewKind) !== Boolean(value.origin.reviewFingerprint)) {
+		context.addIssue({ code: "custom", message: "Correction review kind and fingerprint must be provided together." });
+	}
+	if (value.origin.reviewKind && value.origin.type !== "reviewed_proposal") {
+		context.addIssue({ code: "custom", message: "Correction reviews require a reviewed proposal origin." });
+	}
+	if (value.adjudication.status === "included" && value.origin.reviewFingerprint === contentHash(value.window.expected.proposals)) {
+		context.addIssue({ code: "custom", message: "Correction cases must change or remove the seeded expected proposals before inclusion." });
+	}
 	const messageIds = new Set(value.window.messages.map(message => message.id));
 	for (const [id, reference] of Object.entries(value.reviewContext?.discordMessages ?? {})) {
 		if (!messageIds.has(id)) context.addIssue({ code: "custom", message: `Discord reference points to unknown corpus message ${id}.` });

--- a/src/export-ai-corpus.ts
+++ b/src/export-ai-corpus.ts
@@ -165,6 +165,63 @@ export function buildCorpusWindow(input: ExportRow) {
 	return window.success ? sanitizeCorpusWindow(window.data) : undefined;
 }
 
+export function buildPendingCorrectionWindow(input: ExportRow) {
+	const row = exportRowSchema.parse(input);
+	if (!row.input_snapshot.length || !row.proposals.length || row.proposals.length > 5) return undefined;
+	if (row.source === "manual" && row.decision?.groupedCount !== 1) return undefined;
+	if (!row.proposals.every(proposal => proposal.status === "dismissed" && proposal.reviewOutcome === "dismissed" && proposal.dismissalReason === "incorrect_proposal" && proposal.initialSnapshot)) return undefined;
+	const extractionOptions = row.decision?.extractionOptions;
+	if (extractionOptions && typeof extractionOptions === "object" && "allowSensitiveContent" in extractionOptions && extractionOptions.allowSensitiveContent === true) return undefined;
+	if (row.decision?.windowSensitivity !== undefined && row.decision.windowSensitivity !== "safe") return undefined;
+	const assessments = rowAssessments(row);
+	if (!assessments.length || assessments.some(assessment => !assessment || assessment.sensitivity !== "safe")) return undefined;
+
+	const messageIds = new Map(row.input_snapshot.map((message, index) => [message.id, `m${index + 1}`]));
+	const attachmentIds = new Map(row.input_snapshot.flatMap(message => (message.attachments ?? []).map(attachment => `${message.id}:${attachment.id}`))
+		.map((id, index) => [id, `a${index + 1}`]));
+	const expected = row.proposals.map(proposal => {
+		const snapshot = proposal.initialSnapshot!;
+		const action = z.enum(["create", "update", "complete", "reopen"]).safeParse(snapshot.action).data;
+		const title = stringValue(snapshot.title) ?? proposal.title;
+		const rawSourceIds = Array.isArray(snapshot.sourceMessageIds)
+			? snapshot.sourceMessageIds.filter((id): id is string => typeof id === "string")
+			: proposal.sourceMessageIds;
+		const sourceMessageIds = rawSourceIds.map(id => messageIds.get(id)).filter((id): id is string => Boolean(id));
+		if (!action || !rawSourceIds.length || sourceMessageIds.length !== rawSourceIds.length || !candidateAssessment(row, rawSourceIds)) return undefined;
+		const projectName = snapshot.projectName === null || typeof snapshot.projectName === "string" ? snapshot.projectName : undefined;
+		const assigneeAlias = snapshot.assigneeAlias === null || typeof snapshot.assigneeAlias === "string" ? snapshot.assigneeAlias : undefined;
+		const dueDate = snapshot.dueDate === null || (typeof snapshot.dueDate === "string" && z.iso.date().safeParse(snapshot.dueDate).success) ? snapshot.dueDate : undefined;
+		return {
+			action,
+			titleIncludes: evaluationTitleTerms(title),
+			...(projectName !== undefined ? { projectName } : {}),
+			...(assigneeAlias !== undefined ? { assigneeAlias } : {}),
+			...(dueDate !== undefined ? { dueDate } : {}),
+			sourceMessageIds,
+		};
+	});
+	if (expected.some(proposal => !proposal)) return undefined;
+	const metadata = row.decision?.extractionMetadata;
+	const window = corpusWindowSchema.safeParse({
+		id: `review-${row.id}`,
+		mode: "automatic",
+		messages: row.input_snapshot.map(message => ({
+			id: messageIds.get(message.id), authorAlias: message.authorAlias, text: message.text, timestamp: message.timestamp,
+			...(message.contextRole ? { contextRole: message.contextRole } : {}),
+			...(message.priority ? { priority: true } : {}),
+			...(message.replyTo && messageIds.has(message.replyTo) ? { replyTo: messageIds.get(message.replyTo) } : {}),
+			...(message.attachments?.length ? { attachments: message.attachments.map(attachment => ({
+				id: attachmentIds.get(`${message.id}:${attachment.id}`)!, name: attachment.name,
+				...(attachment.contentType ? { contentType: attachment.contentType } : {}),
+				url: `https://example.invalid/attachment/${attachmentIds.get(`${message.id}:${attachment.id}`)}`,
+			})) } : {}),
+		})),
+		...(metadata && typeof metadata === "object" ? { metadata } : {}),
+		expected: { proposals: expected },
+	});
+	return window.success ? sanitizeCorpusWindow(window.data) : undefined;
+}
+
 export async function loadReviewedExtractionRows(pool: Pick<pg.Pool, "query">, days: number) {
 	const result = await pool.query(
 		`SELECT e.id,e.source,e.input_snapshot,e.message_assessments,e.decision,

--- a/src/sync-ai-corpus.ts
+++ b/src/sync-ai-corpus.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { AzureBlobCorpusStore } from "./ai-corpus-blob.js";
 import { contentHash, corpusCaseSchema, corpusWindowSchema, sanitizeCorpusCase, sanitizeCorpusWindow, type CorpusCase, type CorpusWindow } from "./ai-corpus.js";
 import { loadAiCorpusConfig } from "./ai-corpus-config.js";
-import { buildCorpusWindow, loadReviewedExtractionRows } from "./export-ai-corpus.js";
+import { buildCorpusWindow, buildPendingCorrectionWindow, loadReviewedExtractionRows } from "./export-ai-corpus.js";
 
 const { Pool } = pg;
 const databaseConfigSchema = z.object({ DATABASE_URL: z.string().min(1), ORGANIZER_GUILD_ID: z.string().regex(/^\d+$/) });
@@ -151,7 +151,10 @@ async function main() {
 			if (invalidated) await store.invalidateIncludedExports();
 		}
 		const rows = await loadReviewedExtractionRows(pool, corpusConfig.AI_CORPUS_SYNC_DAYS);
-		const reviewed = rows.map(row => ({ row, window: buildCorpusWindow(row) }));
+		const reviewed = rows.map(row => {
+			const correction = buildPendingCorrectionWindow(row);
+			return { row, window: buildCorpusWindow(row) ?? correction, correction: Boolean(correction) };
+		});
 		const queriedExtractionIds = await pool.query<{ id: string }>(
 			`SELECT id FROM ai_extraction_events WHERE schema_version='v3' AND input_snapshot IS NOT NULL
 			 AND created_at >= now() - ($1::text || ' days')::interval`,
@@ -163,9 +166,12 @@ async function main() {
 			await store.deleteCase(item.id);
 			excluded++;
 		}
-		for (const { row, window } of reviewed) {
+		for (const { row, window, correction } of reviewed) {
 			if (!window) { excluded++; continue; }
-			const value = caseFromWindow(window, { type: "reviewed_proposal", extractionEventId: row.id, fingerprint: contentHash(window) }, discordReviewContext(row.input_snapshot, window, databaseConfig.ORGANIZER_GUILD_ID));
+			const value = caseFromWindow(window, {
+				type: "reviewed_proposal", extractionEventId: row.id, fingerprint: contentHash(window),
+				...(correction ? { reviewKind: "incorrect_proposal" as const, reviewFingerprint: contentHash(window.expected.proposals) } : {}),
+			}, discordReviewContext(row.input_snapshot, window, databaseConfig.ORGANIZER_GUILD_ID));
 			const result = await reconcileCase(store, value);
 			if (result === "imported") imported++; else if (result === "updated") updated++; else unchanged++;
 		}

--- a/test/ai-corpus-management.test.js
+++ b/test/ai-corpus-management.test.js
@@ -53,6 +53,25 @@ test("corpus exclusions require structured reasons and notes for other", () => {
 	assert.throws(() => corpusCaseSchema.parse({ ...sampleCase(), adjudication: { status: "approved", exclusionReasons: [], notes: "" } }));
 });
 
+test("correction cases require paired origin metadata and a changed expected value before inclusion", () => {
+	const pending = sampleCase();
+	pending.origin = {
+		type: "reviewed_proposal", reviewKind: "incorrect_proposal",
+		reviewFingerprint: contentHash(pending.window.expected.proposals),
+	};
+	assert.equal(corpusCaseSchema.parse(pending).adjudication.status, "pending");
+	assert.throws(() => corpusCaseSchema.parse({ ...pending, origin: { ...pending.origin, reviewFingerprint: undefined } }), /provided together/);
+	assert.throws(() => corpusCaseSchema.parse({ ...pending, adjudication: { ...pending.adjudication, status: "included" } }), /change or remove/);
+	const corrected = structuredClone(pending);
+	corrected.window.expected.proposals[0].titleIncludes = ["corrected"];
+	corrected.adjudication.status = "included";
+	assert.equal(corpusCaseSchema.parse(corrected).adjudication.status, "included");
+	const removed = structuredClone(pending);
+	removed.window.expected.proposals = [];
+	removed.adjudication.status = "included";
+	assert.equal(corpusCaseSchema.parse(removed).window.expected.proposals.length, 0);
+});
+
 test("Discord references remain review-only and use canonical message links", () => {
 	const value = sampleCase();
 	value.window.messages[0].channelId = "222";
@@ -91,6 +110,21 @@ test("Discord reference backfills preserve reviewed dispositions", async () => {
 	assert.deepEqual(written.value.window, existing.window);
 	assert.equal(written.value.reviewContext.discordMessages.m1.messageId, "111");
 	assert.equal(written.etag, '"one"');
+});
+
+test("idempotent correction sync preserves human expected output and disposition", async () => {
+	const seeded = sampleCase();
+	const reviewFingerprint = contentHash(seeded.window.expected.proposals);
+	seeded.origin = { type: "reviewed_proposal", fingerprint: "same-source", reviewKind: "incorrect_proposal", reviewFingerprint };
+	const existing = structuredClone(seeded);
+	existing.window.expected.proposals[0].titleIncludes = ["human", "correction"];
+	existing.adjudication.status = "included";
+	let written;
+	assert.equal(await reconcileCase({
+		async getCase() { return { case: existing, etag: '"one"' }; },
+		async putCase(value) { written = value; },
+	}, seeded), "unchanged");
+	assert.equal(written, undefined);
 });
 
 test("Discord reference backfills preserve reconstructed evidence", async () => {
@@ -184,7 +218,7 @@ test("localhost corpus API requires its session token and uses ETags", async () 
 	let value = sampleCase();
 	let etag = '"one"';
 	const store = {
-		async listCases() { return [{ id: value.id, status: value.adjudication.status, originType: value.origin.type, updatedAt: value.updatedAt, messageCount: 1, proposalCount: 1, preview: "sponsor" }]; },
+		async listCases() { return [{ id: value.id, status: value.adjudication.status, originType: value.origin.type, reviewKind: "incorrect_proposal", updatedAt: value.updatedAt, messageCount: 1, proposalCount: 1, preview: "sponsor" }]; },
 		async getCase() { return { case: value, etag }; },
 		async putCase(next, expected) {
 			if (expected && expected !== etag) throw Object.assign(new Error("conflict"), { statusCode: 412 });
@@ -211,6 +245,9 @@ test("localhost corpus API requires its session token and uses ETags", async () 
 		const summary = await fetch(`${base}/api/summary`, { headers: { Cookie: "corpus_session=secret" } });
 		assert.equal(summary.status, 200);
 		assert.equal((await summary.json()).pending, 1);
+		const correctionSearch = await fetch(`${base}/api/cases?query=incorrect_proposal`, { headers: { Cookie: "corpus_session=secret" } });
+		assert.equal(correctionSearch.status, 200);
+		assert.equal((await correctionSearch.json()).cases.length, 1);
 		const unauthorizedRecovery = await fetch(`${base}/api/cases/case-1/reconstruction-preview`, {
 			method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ etag: '"one"', messageUrls: ["url"] }),
 		});

--- a/test/ai-corpus.test.js
+++ b/test/ai-corpus.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildCorpusWindow, evaluationTitleTerms } from "../dist/export-ai-corpus.js";
+import { buildCorpusWindow, buildPendingCorrectionWindow, evaluationTitleTerms } from "../dist/export-ai-corpus.js";
 
 function reviewedRow(overrides = {}) {
 	return {
@@ -87,4 +87,58 @@ test("automatic events use their dedicated candidate assessments", () => {
 	assert.equal(buildCorpusWindow(automatic).expected.proposals.length, 1);
 	automatic.message_assessments[0].sensitivity = "sensitive";
 	assert.equal(buildCorpusWindow(automatic), undefined);
+});
+
+test("incorrect proposals build sync-only pending correction windows from the full safe snapshot", () => {
+	const row = reviewedRow({
+		input_snapshot: [
+			...reviewedRow().input_snapshot,
+			{ id: "context-message", authorAlias: "Person B", text: "This context must remain available.", timestamp: "2026-07-20T12:59:00.000Z", contextRole: "preceding" },
+		],
+		decision: {
+			groupedCount: 1, windowSensitivity: "safe", extractionMetadata: { projects: ["Partnerships"] },
+			candidateAssessments: [{ proposedAction: "create", sourceMessageIds: ["discord-message"], sensitivity: "safe" }],
+		},
+		proposals: [{
+			status: "dismissed", reviewOutcome: "dismissed", dismissalReason: "incorrect_proposal", action: "create",
+			targetWorkPackageId: null, title: "Revise the sponsor deck", sourceMessageIds: ["discord-message"],
+			initialSnapshot: { title: "Revise the sponsor deck", action: "create", sourceMessageIds: ["discord-message"], projectName: "Partnerships", dueDate: "2026-08-01" }, finalSnapshot: null,
+		}],
+	});
+	const window = buildPendingCorrectionWindow(row);
+	assert.equal(buildCorpusWindow(row), undefined);
+	assert.equal(window.messages.length, 2);
+	assert.deepEqual(window.expected.proposals, [{
+		action: "create", titleIncludes: ["sponsor", "deck"], projectName: "Partnerships", dueDate: "2026-08-01", sourceMessageIds: ["m1"],
+	}]);
+});
+
+test("correction builder excludes unsafe, ungrounded, mixed, overridden, and oversized cases", () => {
+	const correction = () => {
+		const row = reviewedRow();
+		row.decision.windowSensitivity = "safe";
+		row.proposals[0] = { ...row.proposals[0], status: "dismissed", reviewOutcome: "dismissed", dismissalReason: "incorrect_proposal", finalSnapshot: null };
+		return row;
+	};
+	const unsafe = correction();
+	unsafe.decision.windowSensitivity = "unsafe";
+	assert.equal(buildPendingCorrectionWindow(unsafe), undefined);
+	const override = correction();
+	override.decision.extractionOptions = { allowSensitiveContent: true };
+	assert.equal(buildPendingCorrectionWindow(override), undefined);
+	const regrouped = correction();
+	regrouped.decision.groupedCount = 2;
+	assert.equal(buildPendingCorrectionWindow(regrouped), undefined);
+	const missingSource = correction();
+	missingSource.proposals[0].initialSnapshot.sourceMessageIds = ["missing"];
+	assert.equal(buildPendingCorrectionWindow(missingSource), undefined);
+	const unmatchedAssessment = correction();
+	unmatchedAssessment.decision.candidateAssessments[0].sourceMessageIds = ["other"];
+	assert.equal(buildPendingCorrectionWindow(unmatchedAssessment), undefined);
+	const mixed = correction();
+	mixed.proposals.push({ ...structuredClone(mixed.proposals[0]), dismissalReason: "not_actionable" });
+	assert.equal(buildPendingCorrectionWindow(mixed), undefined);
+	const oversized = correction();
+	oversized.proposals = Array.from({ length: 6 }, () => structuredClone(oversized.proposals[0]));
+	assert.equal(buildPendingCorrectionWindow(oversized), undefined);
 });


### PR DESCRIPTION
## Summary
- import safe Incorrect outcomes into the private corpus desk as pending correction drafts
- prevent unchanged rejected outputs from being included or exported
- preserve full safe context and human corrections across syncs
- add correction search markers and project editing to the private desk

## Safety
- legacy corpus export still excludes Incorrect outcomes
- sensitive overrides, unsafe or ungrounded windows, mixed outcomes, and oversized drafts remain excluded
- no database migration

## Verification
- npm test (206 tests passed)