### PR TITLE
feat(tasks): explain proposal review outcomes

### DIFF
--- a/src/automatic-tasks.ts
+++ b/src/automatic-tasks.ts
@@ -3,7 +3,7 @@ import { automaticCandidateEligible, containsSensitiveContent, extractionDiagnos
 import { isOrganizerGuild, type IntegrationConfig } from "./config.js";
 import { Database } from "./database.js";
 import { OpenProjectClient, titlesLikelyDuplicate, workPackageMarkdownLink } from "./openproject.js";
-import { AI_CONTEXT_GAP_MS, boundedDiscordContent, defaultAiDueDate, formatAiTaskDescription, inferCreationMetadata, proposalReviewAllowed, proposalReviewComponents, relevantImageAttachments } from "./tasks.js";
+import { AI_CONTEXT_GAP_MS, defaultAiDueDate, formatAiTaskDescription, inferCreationMetadata, proposalReviewAllowed, proposalReviewCardContent, proposalReviewComponents, relevantImageAttachments } from "./tasks.js";
 import { resolveProposalTarget, type OpenProjectRag } from "./rag.js";
 import { describeProposalOperations, formatProposalContent, planExistingTaskOperations, sourceContentHash, taskReferencesAreValid } from "./task-proposals.js";
 import { isExcludedChannel, projectIdForTeamRoles, projectIdFromChannelNames, resolveProjectId } from "./project-resolution.js";
@@ -413,7 +413,7 @@ export function registerAutomaticTaskDetection(client: Client, services: Automat
 						retentionDays: services.config.OPENPROJECT_PROPOSAL_RETENTION_DAYS,
 					});
 					const reviewPayload: ReviewCardPayload = {
-						content: boundedDiscordContent(`${ownerText}Proposed ${action} for OpenProject task ${workPackageMarkdownLink(target!.id, target!.subject, services.openProject.workPackageUrl(target!.id))}\nProposed title: **${task.title}**\n${describeProposalOperations(operations.contentOperation, operations.metadataPatch, { assignee: assignee?.displayName ?? assignee?.user.username, priority: priority?.name, size: size?.value }).map(item => `- ${item}`).join("\n")}${operations.contentOperation === "descriptionReplacement" ? "\nThis will replace the canonical task description." : ""}${formatProposalContent(operations.contentOperation, operations.contentMarkdown)}${result.ambiguities.length ? `\n\nAmbiguities: ${result.ambiguities.join("; ")}` : ""}`),
+						content: proposalReviewCardContent(`${ownerText}Proposed ${action} for OpenProject task ${workPackageMarkdownLink(target!.id, target!.subject, services.openProject.workPackageUrl(target!.id))}\nProposed title: **${task.title}**\n${describeProposalOperations(operations.contentOperation, operations.metadataPatch, { assignee: assignee?.displayName ?? assignee?.user.username, priority: priority?.name, size: size?.value }).map(item => `- ${item}`).join("\n")}${operations.contentOperation === "descriptionReplacement" ? "\nThis will replace the canonical task description." : ""}${formatProposalContent(operations.contentOperation, operations.contentMarkdown)}${result.ambiguities.length ? `\n\nAmbiguities: ${result.ambiguities.join("; ")}` : ""}`),
 						components: proposalReviewComponents(proposal.id, action, ragCandidates),
 						allowedMentions: { parse: [] },
 					};
@@ -487,7 +487,7 @@ export function registerAutomaticTaskDetection(client: Client, services: Automat
 						ragCandidates,
 				});
 				const reviewPayload: ReviewCardPayload = {
-					content: boundedDiscordContent(`${ownerText}Proposed OpenProject task: **${task.title}**\n${description}\n\nProject: ${projects.find(item => item.id === projectId)?.name ?? "Not resolved"}\nPriority: ${priority?.name ?? "Not inferred"}\nSize: ${size?.value ?? "Not inferred"}\nDates: ${task.start_date ?? "Not set"} → ${dueDate}\nEstimate: ${estimatedHours !== undefined ? `${estimatedHours}h` : "Not inferred"}${advisory ? `\n\n${advisory}` : ""}${result.ambiguities.length ? `\n\nAmbiguities: ${result.ambiguities.join("; ")}` : ""}`),
+					content: proposalReviewCardContent(`${ownerText}Proposed OpenProject task: **${task.title}**\n${description}\n\nProject: ${projects.find(item => item.id === projectId)?.name ?? "Not resolved"}\nPriority: ${priority?.name ?? "Not inferred"}\nSize: ${size?.value ?? "Not inferred"}\nDates: ${task.start_date ?? "Not set"} → ${dueDate}\nEstimate: ${estimatedHours !== undefined ? `${estimatedHours}h` : "Not inferred"}${advisory ? `\n\n${advisory}` : ""}${result.ambiguities.length ? `\n\nAmbiguities: ${result.ambiguities.join("; ")}` : ""}`),
 					components: proposalReviewComponents(proposal.id, "create", ragCandidates),
 					allowedMentions: { parse: [] },
 				};

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -261,6 +261,13 @@ export function boundedDiscordContent(value: string, limit = 2000) {
 	return `${body}${closers}${suffix}`.slice(0, limit);
 }
 
+export const proposalReviewExplanation = "`Review` opens editing and approval. `Dismiss` means no task exists. `Incorrect` means work exists, but this proposal is wrong.";
+
+export function proposalReviewCardContent(value: string) {
+	const separator = "\n\n";
+	return `${boundedDiscordContent(value, 2000 - separator.length - proposalReviewExplanation.length)}${separator}${proposalReviewExplanation}`;
+}
+
 type ProposalReviewMessage = { id: string; channel_id: string; review_message_id: string | null };
 
 function discordErrorCode(error: unknown) {
@@ -1933,7 +1940,7 @@ async function completeAiCandidate(
 		const displayedAmbiguities = redisplayed?.ambiguities ?? result.ambiguities;
 		const warning = displayedOperation === "descriptionReplacement" ? "\nThis will replace the canonical task description." : "";
 		const reviewPayload: InteractionEditReplyOptions = {
-			content: boundedDiscordContent(`**Possible ${displayedAction} for ${displayedWorkPackageLink}**\n${operationSummary.map(item => `- ${item}`).join("\n")}${warning}${formatProposalContent(displayedOperation, displayedContent)}${redisplayed ? "" : `\n\nSimilarity: ${Math.round(match.similarity * 100)}%`}${displayedAmbiguities.length ? `\nAmbiguities: ${displayedAmbiguities.join("; ")}` : ""}`),
+			content: proposalReviewCardContent(`**Possible ${displayedAction} for ${displayedWorkPackageLink}**\n${operationSummary.map(item => `- ${item}`).join("\n")}${warning}${formatProposalContent(displayedOperation, displayedContent)}${redisplayed ? "" : `\n\nSimilarity: ${Math.round(match.similarity * 100)}%`}${displayedAmbiguities.length ? `\nAmbiguities: ${displayedAmbiguities.join("; ")}` : ""}`),
 			components: proposalReviewComponents(proposal.id, displayedAction, redisplayed?.rag_candidates ?? ragCandidates),
 		};
 		if (proposal.revised) await updateProposalReviewCard(interaction, services, proposal.id, reviewPayload);
@@ -2038,7 +2045,7 @@ async function completeAiCandidate(
 		cardBody = `**${redisplayed?.title ?? candidate.title}**\n${redisplayed?.description ?? description}\n\n${details}`;
 	}
 	const reviewPayload: InteractionEditReplyOptions = {
-		content: boundedDiscordContent(`${cardBody}${displayedAmbiguities.length ? `\n\nAmbiguities: ${displayedAmbiguities.join("; ")}` : ""}`),
+		content: proposalReviewCardContent(`${cardBody}${displayedAmbiguities.length ? `\n\nAmbiguities: ${displayedAmbiguities.join("; ")}` : ""}`),
 		components: proposalReviewComponents(proposal.id, displayedAction, displayedAction === "create" ? redisplayed?.rag_candidates ?? ragCandidates : []),
 	};
 	if (proposal.revised) await updateProposalReviewCard(interaction, services, proposal.id, reviewPayload);
@@ -2128,7 +2135,7 @@ async function applyExistingProposalTarget(
 	const resultingAction = proposal.action === "create" ? "update" : proposal.action;
 	const buttons = manualProposalButtons(proposal.id, resultingAction);
 	await interaction.editReply({
-		content: boundedDiscordContent(`Proposal will ${resultingAction} OpenProject task ${workPackageMarkdownLink(target.id, target.subject, services.openProject.workPackageUrl(target.id))}\nProposed title: **${proposal.title}**\n${describeProposalOperations(operations.contentOperation, operations.metadataPatch, await proposalMetadataDisplayNames(interaction.guild!, services, operations.metadataPatch, targetProjectId)).map(item => `- ${item}`).join("\n")}${formatProposalContent(operations.contentOperation, operations.contentMarkdown)}${proposal.ambiguities.length ? `\n\nAmbiguities: ${proposal.ambiguities.join("; ")}` : ""}`),
+		content: proposalReviewCardContent(`Proposal will ${resultingAction} OpenProject task ${workPackageMarkdownLink(target.id, target.subject, services.openProject.workPackageUrl(target.id))}\nProposed title: **${proposal.title}**\n${describeProposalOperations(operations.contentOperation, operations.metadataPatch, await proposalMetadataDisplayNames(interaction.guild!, services, operations.metadataPatch, targetProjectId)).map(item => `- ${item}`).join("\n")}${formatProposalContent(operations.contentOperation, operations.contentMarkdown)}${proposal.ambiguities.length ? `\n\nAmbiguities: ${proposal.ambiguities.join("; ")}` : ""}`),
 		components: [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)],
 		allowedMentions: { parse: [] },
 	});

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { AI_CONTEXT_GAP_MS, appendRelevantUrls, appendSourceLinks, boundedDiscordContent, calendarDate, citesExtractionFocus, continuationScore, databaseDate, dateChoices, defaultAiDueDate, defaultTaskDates, directProposalDismissalReason, explicitAssignmentNames, followingUntilGap, formatProposalMetrics, handleProposalButton, handleProposalTargetSelect, historicalContinuityScore, inferCreationMetadata, isExcludedChannel, manualProposalButtons, precedingUntilGap, projectAccessAllowed, proposalCorrections, proposalIsReviewable, proposalReviewAllowed, proposalReviewComponents, relevantImageAttachments, removeProposalReviewCard, reviewedProposalAllowsDuplicate, taskCommand, taskOwnerIds, validIsoDate } from "../dist/tasks.js";
+import { AI_CONTEXT_GAP_MS, appendRelevantUrls, appendSourceLinks, boundedDiscordContent, calendarDate, citesExtractionFocus, continuationScore, databaseDate, dateChoices, defaultAiDueDate, defaultTaskDates, directProposalDismissalReason, explicitAssignmentNames, followingUntilGap, formatProposalMetrics, handleProposalButton, handleProposalTargetSelect, historicalContinuityScore, inferCreationMetadata, isExcludedChannel, manualProposalButtons, precedingUntilGap, projectAccessAllowed, proposalCorrections, proposalIsReviewable, proposalReviewAllowed, proposalReviewCardContent, proposalReviewComponents, proposalReviewExplanation, relevantImageAttachments, removeProposalReviewCard, reviewedProposalAllowsDuplicate, taskCommand, taskOwnerIds, validIsoDate } from "../dist/tasks.js";
 import { formatProposalContent } from "../dist/task-proposals.js";
 import { normalizeTaskTitle, OpenProjectClient, openProjectAttachmentFileName, titlesLikelyDuplicate, workPackageMarkdownLink } from "../dist/openproject.js";
 
@@ -386,6 +386,17 @@ test("proposal card truncation preserves Markdown boundaries", () => {
 
 	const doubleBackticks = boundedDiscordContent(`${"Context ".repeat(5)}\`\`code ** ${"detail ".repeat(20)}`, 120);
 	assert.match(doubleBackticks, /``\n\n\[Preview truncated\]$/);
+});
+
+test("proposal review cards explain direct outcomes within Discord limits", () => {
+	const content = proposalReviewCardContent("Task details");
+	assert.match(content, /Task details/);
+	assert.equal(content.split(proposalReviewExplanation).length - 1, 1);
+
+	const truncated = proposalReviewCardContent("x".repeat(4000));
+	assert.equal(truncated.length <= 2000, true);
+	assert.match(truncated, /\[Preview truncated\]/);
+	assert.equal(truncated.split(proposalReviewExplanation).length - 1, 1);
 });
 
 test("work package proposal links include the ID and title", () => {


### PR DESCRIPTION
## Summary
- add one concise footer explaining Review, Dismiss, and Incorrect semantics
- apply the footer to automatic, manual, revised, and retargeted proposal cards
- preserve Discord's 2,000-character limit and existing controls

## Validation
- npm test (203 passed)