### PR TITLE
fix(ai): enforce whole-window sensitivity

### DIFF
--- a/src/automatic-tasks.ts
+++ b/src/automatic-tasks.ts
@@ -288,10 +288,10 @@ export function registerAutomaticTaskDetection(client: Client, services: Automat
 			}
 			const reconciledTasks = reconciliation.proposals;
 			const gate = completedGate = await services.extractor.assessAutomaticCandidates(extraction.inputMessages, reconciledTasks.map(item => item.candidate));
-			const eligibleTasks = reconciledTasks.filter((_, index) => automaticCandidateEligible(gate.assessments[index]));
+			const eligibleTasks = reconciledTasks.filter((_, index) => automaticCandidateEligible(gate.assessments[index], gate.windowSensitivity));
 			const candidateAssessments = reconciledTasks.map(({ candidate: task }, index) => ({
 				...gate.assessments[index],
-				automaticEligibility: automaticCandidateEligible(gate.assessments[index]) ? "eligible" : "ineligible",
+				automaticEligibility: automaticCandidateEligible(gate.assessments[index], gate.windowSensitivity) ? "eligible" : "ineligible",
 				proposedAction: task.proposed_action,
 				sourceMessageIds: task.source_message_ids,
 			}));

--- a/src/azure-openai.ts
+++ b/src/azure-openai.ts
@@ -187,8 +187,8 @@ export type ProposalReconciliationResult = {
 	usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
 };
 
-export function automaticCandidateEligible(assessment?: AutomaticCandidateAssessment) {
-	return Boolean(assessment
+export function automaticCandidateEligible(assessment: AutomaticCandidateAssessment | undefined, windowSensitivity: AutomaticGateResult["windowSensitivity"]) {
+	return Boolean(windowSensitivity === "safe" && assessment
 		&& assessment.has_activated_specific_work
 		&& assessment.has_remaining_work_or_trackable_transition
 		&& assessment.is_durable

--- a/src/evaluate-ai.ts
+++ b/src/evaluate-ai.ts
@@ -35,10 +35,11 @@ export function runtimeProposalCandidates(
 	routing: { availableTargetSourceMessageIds?: string[][] } = {},
 	mode: "manual" | "automatic" = "automatic",
 	automaticAssessments: AutomaticCandidateAssessment[] = [],
+	windowSensitivity: "safe" | "sensitive" | "uncertain" = "uncertain",
 ) {
 	const grounded = runtimeGroundedCandidates(tasks, messages);
 	const eligible = mode === "automatic"
-		? grounded.filter((_, index) => automaticCandidateEligible(automaticAssessments[index]))
+		? grounded.filter((_, index) => automaticCandidateEligible(automaticAssessments[index], windowSensitivity))
 		: grounded;
 	return eligible.filter(task => {
 		const targetAvailable = routing.availableTargetSourceMessageIds?.some(ids => ids.every(id => task.source_message_ids.includes(id))) ?? false;
@@ -75,7 +76,7 @@ function sleep(milliseconds: number) {
 	return new Promise(resolveSleep => setTimeout(resolveSleep, milliseconds));
 }
 
-const EVALUATOR_PIPELINE_VERSION = "automatic-v3.4";
+const EVALUATOR_PIPELINE_VERSION = "automatic-v3.5";
 const evaluationTraceSchema = z.object({
 	extractedCandidates: z.number().int().min(0),
 	groundedCandidates: z.number().int().min(0),
@@ -230,16 +231,18 @@ async function main() {
 			totalTokens += extraction.usage?.totalTokens ?? 0;
 			const grounded = runtimeGroundedCandidates(extraction.result.tasks, window.messages as MinimizedMessage[]);
 			let assessments: AutomaticCandidateAssessment[] = [];
+			let windowSensitivity: "safe" | "sensitive" | "uncertain" = window.mode === "manual" ? "safe" : "uncertain";
 			if (window.mode === "automatic" && grounded.length) {
 				const waitForGate = Math.max(0, env.AI_EVAL_MIN_INTERVAL_MS - (Date.now() - lastRequestAt));
 				if (waitForGate) await sleep(waitForGate);
 				lastRequestAt = Date.now();
 				const gate = await extractor.assessAutomaticCandidates(extraction.inputMessages, grounded);
 				assessments = gate.assessments;
+				windowSensitivity = gate.windowSensitivity;
 				totalLatencyMs += gate.latencyMs;
 				totalTokens += gate.usage?.totalTokens ?? 0;
 			}
-			predicted = runtimeProposalCandidates(extraction.result.tasks, window.messages as MinimizedMessage[], window.routing, window.mode, assessments);
+			predicted = runtimeProposalCandidates(extraction.result.tasks, window.messages as MinimizedMessage[], window.routing, window.mode, assessments, windowSensitivity);
 			trace = evaluationTrace(extraction.result.tasks.length, grounded.length, assessments, predicted.length);
 			await storePrediction(env.AI_EVAL_CACHE_DIR, item.key, predicted, trace);
 			validOutputs++;

--- a/src/replay-ai.ts
+++ b/src/replay-ai.ts
@@ -72,7 +72,7 @@ async function main() {
 				const validAttachmentIds = new Set(messages.flatMap(message => (message.attachments ?? []).map(attachment => attachment.id)));
 				const candidates = mergeRelatedTaskCandidates(extraction.result.tasks.filter(task => taskReferencesAreValid(task, validMessageIds, focalMessageIds, validAttachmentIds)));
 				if (candidates.length) await new Promise(resolve => setTimeout(resolve, config.AI_REPLAY_MIN_INTERVAL_MS));
-				const gate = candidates.length ? await extractor.assessAutomaticCandidates(extraction.inputMessages, candidates) : { assessments: [] };
+				const gate = candidates.length ? await extractor.assessAutomaticCandidates(extraction.inputMessages, candidates) : { windowSensitivity: "uncertain" as const, assessments: [] };
 				console.log(JSON.stringify({
 					id: row.id,
 					source: row.source,
@@ -81,7 +81,7 @@ async function main() {
 					candidates: candidates.map((task, index) => ({
 						title: task.title,
 						action: task.proposed_action,
-						automaticEligibility: automaticCandidateEligible(gate.assessments[index]) ? "eligible" : "ineligible",
+						automaticEligibility: automaticCandidateEligible(gate.assessments[index], gate.windowSensitivity) ? "eligible" : "ineligible",
 						assessment: gate.assessments[index],
 						sourceMessageIds: task.source_message_ids,
 					})),

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1656,8 +1656,9 @@ async function completeAiContext(
 	extraction.usage = combinedTokenUsage(extraction.usage, reconciliation.usage);
 	const gate = await services.extractor.assessAutomaticCandidates(extraction.inputMessages, candidates.map(item => item.candidate));
 	const contextualSensitivity = gate.assessments.filter(assessment => assessment.sensitivity !== "safe");
-	if (contextualSensitivity.length && !allowSensitiveContent) {
+	if ((gate.windowSensitivity !== "safe" || contextualSensitivity.length) && !allowSensitiveContent) {
 		throw attachExtractionDiagnostics(new SensitiveContentError([
+			...(gate.windowSensitivity !== "safe" ? [`Window sensitivity: ${gate.windowSensitivity}`] : []),
 			...new Set(contextualSensitivity.map(assessment => `Contextual sensitivity: ${assessment.sensitivity}`)),
 		]), {
 			inputMessages: extraction.inputMessages,
@@ -1670,7 +1671,7 @@ async function completeAiContext(
 	extraction.usage = combinedTokenUsage(extraction.usage, gate.usage);
 	const decisionTelemetry = {
 		taskCount: result.tasks.length,
-		automaticEligibleCount: candidates.filter((_, index) => automaticCandidateEligible(gate.assessments[index])).length,
+		automaticEligibleCount: candidates.filter((_, index) => automaticCandidateEligible(gate.assessments[index], gate.windowSensitivity)).length,
 		invalidGroundingCount: result.tasks.length - individuallyGroundedCandidates.length,
 		groupedCount: groupedCandidates.length,
 		reconciledCount: candidates.length,
@@ -1679,7 +1680,7 @@ async function completeAiContext(
 		primaryMessageIds: [...context.focusIds],
 		candidateAssessments: candidates.map(({ candidate: task }, index) => ({
 			...gate.assessments[index],
-			automaticEligibility: automaticCandidateEligible(gate.assessments[index]) ? "eligible" : "ineligible",
+			automaticEligibility: automaticCandidateEligible(gate.assessments[index], gate.windowSensitivity) ? "eligible" : "ineligible",
 			proposedAction: task.proposed_action,
 			sourceMessageIds: task.source_message_ids,
 		})),

--- a/test/azure-openai.test.js
+++ b/test/azure-openai.test.js
@@ -309,10 +309,11 @@ test("automatic eligibility requires every precision check and safe context", ()
 		candidate_index: 0, has_activated_specific_work: true, has_remaining_work_or_trackable_transition: true,
 		is_durable: true, is_decision_ready: true, sensitivity: "safe", supporting_source_message_ids: ["m1"],
 	};
-	assert.equal(automaticCandidateEligible(eligible), true);
-	assert.equal(automaticCandidateEligible({ ...eligible, is_decision_ready: false }), false);
-	assert.equal(automaticCandidateEligible({ ...eligible, sensitivity: "uncertain" }), false);
-	assert.equal(automaticCandidateEligible(undefined), false);
+	assert.equal(automaticCandidateEligible(eligible, "safe"), true);
+	assert.equal(automaticCandidateEligible(eligible, "uncertain"), false);
+	assert.equal(automaticCandidateEligible({ ...eligible, is_decision_ready: false }, "safe"), false);
+	assert.equal(automaticCandidateEligible({ ...eligible, sensitivity: "uncertain" }, "safe"), false);
+	assert.equal(automaticCandidateEligible(undefined, "safe"), false);
 });
 
 test("related corrections with one work item key are merged", () => {
@@ -371,7 +372,7 @@ test("automatic precision gate judges raw evidence and validates complete candid
 		const gate = await new AzureTaskExtractor(config, async () => "token").assessAutomaticCandidates([
 			{ id: "m1", authorAlias: "USER_1", text: "I have a reel ready. How does Instagram access work?", timestamp: "2026-07-13T00:00:00Z", contextRole: "primary" },
 		], [candidate]);
-		assert.equal(automaticCandidateEligible(gate.assessments[0]), false);
+		assert.equal(automaticCandidateEligible(gate.assessments[0], gate.windowSensitivity), false);
 		assert.equal(gate.windowSensitivity, "safe");
 		assert.equal(gate.usage.totalTokens, 42);
 		assert.equal(request.response_format.json_schema.name, "discord_automatic_precision_gate_v1");

--- a/test/openproject-rag.test.js
+++ b/test/openproject-rag.test.js
@@ -464,10 +464,11 @@ test("AI evaluator uses production grounding and target semantics for every acti
 		is_durable: true, is_decision_ready: true, sensitivity: "safe", supporting_source_message_ids: ["m1"],
 	};
 	const messages = [{ id: "m1", authorAlias: "USER_1", text: "Update it", timestamp: "2026-07-16T00:00:00Z", priority: true }];
-	assert.deepEqual(runtimeProposalCandidates([candidate], messages, {}, "automatic", [eligible]), [candidate]);
-	assert.deepEqual(runtimeProposalCandidates([candidate], messages, { availableTargetSourceMessageIds: [["m1"]] }, "automatic", [eligible]), [candidate]);
-	assert.deepEqual(runtimeProposalCandidates([{ ...candidate, source_message_ids: ["other"] }], messages, {}, "automatic", [eligible]), []);
-	assert.deepEqual(runtimeProposalCandidates([candidate], messages, { availableTargetSourceMessageIds: [["m1"]] }, "automatic", [{ ...eligible, is_durable: false }]), []);
+	assert.deepEqual(runtimeProposalCandidates([candidate], messages, {}, "automatic", [eligible], "safe"), [candidate]);
+	assert.deepEqual(runtimeProposalCandidates([candidate], messages, {}, "automatic", [eligible], "sensitive"), []);
+	assert.deepEqual(runtimeProposalCandidates([candidate], messages, { availableTargetSourceMessageIds: [["m1"]] }, "automatic", [eligible], "safe"), [candidate]);
+	assert.deepEqual(runtimeProposalCandidates([{ ...candidate, source_message_ids: ["other"] }], messages, {}, "automatic", [eligible], "safe"), []);
+	assert.deepEqual(runtimeProposalCandidates([candidate], messages, { availableTargetSourceMessageIds: [["m1"]] }, "automatic", [{ ...eligible, is_durable: false }], "safe"), []);
 	assert.deepEqual(runtimeProposalCandidates([candidate], messages, {}, "manual"), [candidate]);
 });
 


### PR DESCRIPTION
## Summary
- require a safe whole-window classification before automatic proposal eligibility
- enforce the same rule in production, replay, manual sensitivity checks, and private evaluation
- invalidate evaluator cache entries for the policy change

## Validation
- npm test (203 passed)