### PR TITLE
fix(runtime): tolerate restricted user directory access

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -82,8 +82,9 @@ client.once("clientReady", async () => {
 			rag,
 		};
 		const organizerGuild = await client.guilds.fetch(integrationConfig.ORGANIZER_GUILD_ID);
-		const initialReconciliation = await reconcileOpenProjectUsers(organizerGuild, integrationConfig, db, services.openProject);
-		console.log("Initial OpenProject identity reconciliation complete", initialReconciliation);
+		await reconcileOpenProjectUsers(organizerGuild, integrationConfig, db, services.openProject)
+			.then(result => console.log("Initial OpenProject identity reconciliation complete", result))
+			.catch(error => console.error("Initial OpenProject identity reconciliation failed", { error: (error as Error).message }));
 		registerTaskInteractions(client, services);
 		registerAutomaticTaskDetection(client, services);
 		const cleanupReviewCards = () => void cleanupTerminalProposalCards(client, db)

--- a/src/openproject.ts
+++ b/src/openproject.ts
@@ -47,7 +47,7 @@ function detectedImageType(bytes: Uint8Array) {
 }
 
 export class OpenProjectRequestError extends Error {
-	constructor(message: string, readonly ambiguous = false) {
+	constructor(message: string, readonly ambiguous = false, readonly status?: number) {
 		super(message);
 	}
 }
@@ -139,7 +139,7 @@ export class OpenProjectClient {
 				if (!response.ok) {
 					const body = await response.text();
 					if (method === "GET" && response.status >= 500 && attempt + 1 < attempts) continue;
-					throw new OpenProjectRequestError(`OpenProject ${response.status}: ${body.slice(0, 500)}`);
+					throw new OpenProjectRequestError(`OpenProject ${response.status}: ${body.slice(0, 500)}`, false, response.status);
 				}
 				return (await response.json()) as T;
 			} catch (error) {
@@ -276,7 +276,15 @@ export class OpenProjectClient {
 
 	async linkableUsers() {
 		return this.cached("linkable-users", async () => {
-			const users = await this.collection<OpenProjectUser>("/api/v3/users?pageSize=500");
+			let users: OpenProjectUser[];
+			try {
+				users = await this.collection<OpenProjectUser>("/api/v3/users?pageSize=500");
+			} catch (error) {
+				if (!(error instanceof OpenProjectRequestError) || error.status !== 403) throw error;
+				const projects = await this.projects();
+				const projectUsers = await Promise.all(projects.map(project => this.availableAssignees(project.id)));
+				users = [...new Map(projectUsers.flat().map(user => [user.id, user])).values()];
+			}
 			return users
 				.filter(user => (user._type === "User" || !user._type) && (!user.status || user.status === "active" || user.status === "invited"))
 				.sort((left, right) => left.name.localeCompare(right.name));

--- a/test/openproject-rag.test.js
+++ b/test/openproject-rag.test.js
@@ -304,6 +304,31 @@ test("automatic user catalog uses active and invited non-group accounts instead 
 	}
 });
 
+test("user catalog falls back to project assignees when the global directory is forbidden", async () => {
+	const originalFetch = globalThis.fetch;
+	const paths = [];
+	globalThis.fetch = async url => {
+		const path = new URL(String(url)).pathname;
+		paths.push(path);
+		if (path === "/api/v3/users") return new Response("Missing permission", { status: 403 });
+		if (path === "/api/v3/projects") return Response.json({
+			_embedded: { elements: [{ id: 9, name: "Project", active: true }] },
+			_links: {},
+		});
+		return Response.json({
+			_embedded: { elements: [{ id: 1, name: "Project Member", status: "active", _type: "User" }] },
+			_links: {},
+		});
+	};
+	try {
+		const client = new OpenProjectClient({ OPENPROJECT_BASE_URL: "https://openproject.example", OPENPROJECT_API_KEY: "secret", OPENPROJECT_CACHE_TTL_MS: 1000 });
+		assert.deepEqual((await client.users()).map(user => user.id), [1]);
+		assert.deepEqual(paths, ["/api/v3/users", "/api/v3/projects", "/api/v3/workspaces/9/available_assignees"]);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test("OpenProject updates reject stale proposal lock versions before PATCH", async () => {
 	const originalFetch = globalThis.fetch;
 	let calls = 0;


### PR DESCRIPTION
## Summary
- fall back to project-visible assignees when OpenProject denies the global user directory
- preserve full active/invited user discovery when the token has permission
- keep the bot running if initial identity reconciliation fails

## Verification
- npm test (246 passing)
- npm run build
- git diff --check

## Production context
Revision 0000116 currently exits at startup because the OpenProject token receives 403 MissingPermission for /api/v3/users. Migrations succeeded and the previous healthy revision remains active in shadow mode.