### PR TITLE
fix(identity): consider alternate Discord names

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -3,7 +3,7 @@ import type { IntegrationConfig } from "./config.js";
 import type { Database } from "./database.js";
 import type { OpenProjectClient, OpenProjectUser } from "./openproject.js";
 
-export type DiscordIdentity = { id: string; displayName: string; teamGroupIds: number[] };
+export type DiscordIdentity = { id: string; displayName: string; alternateNames?: string[]; teamGroupIds: number[] };
 export type IdentityMatch = { user: OpenProjectUser; reason: "exact_name" | "last_initial" | "team" | "unique_first_name" };
 export type IdentityResolution = {
 	openProjectId?: number;
@@ -21,12 +21,13 @@ function discordNameParts(displayName: string) {
 	return normalizedName(withoutTeams).split(" ").filter(Boolean);
 }
 
-export function matchOpenProjectIdentity(
-	identity: DiscordIdentity,
+function matchOpenProjectName(
+	displayName: string,
+	teamGroupIds: number[],
 	users: OpenProjectUser[],
 	groupUsers: Map<number, Set<number>>,
 ): IdentityMatch | undefined {
-	const discordParts = discordNameParts(identity.displayName);
+	const discordParts = discordNameParts(displayName);
 	if (!discordParts.length) return undefined;
 	const candidates = users.filter(user => normalizedName(user.name).split(" ")[0] === discordParts[0]);
 	if (!candidates.length) return undefined;
@@ -34,18 +35,36 @@ export function matchOpenProjectIdentity(
 	const exact = candidates.filter(user => normalizedName(user.name) === discordParts.join(" "));
 	if (exact.length === 1) return { user: exact[0], reason: "exact_name" };
 
-	const teamCandidates = identity.teamGroupIds.length
-		? candidates.filter(user => identity.teamGroupIds.some(groupId => groupUsers.get(groupId)?.has(user.id)))
+	const teamCandidates = teamGroupIds.length
+		? candidates.filter(user => teamGroupIds.some(groupId => groupUsers.get(groupId)?.has(user.id)))
 		: [];
-	const scoped = identity.teamGroupIds.length ? teamCandidates : candidates;
+	const scoped = teamGroupIds.length ? teamCandidates : candidates;
 	if (discordParts.length >= 2) {
 		const initial = discordParts.at(-1)![0];
 		const initialMatches = scoped.filter(user => normalizedName(user.name).split(" ").slice(1).some(part => part.startsWith(initial)));
 		if (initialMatches.length === 1) return { user: initialMatches[0], reason: "last_initial" };
 	}
 	if (teamCandidates.length === 1) return { user: teamCandidates[0], reason: "team" };
-	if (!identity.teamGroupIds.length && candidates.length === 1) return { user: candidates[0], reason: "unique_first_name" };
+	if (!teamGroupIds.length && candidates.length === 1) return { user: candidates[0], reason: "unique_first_name" };
 	return undefined;
+}
+
+export function matchOpenProjectIdentity(
+	identity: DiscordIdentity,
+	users: OpenProjectUser[],
+	groupUsers: Map<number, Set<number>>,
+): IdentityMatch | undefined {
+	const primary = matchOpenProjectName(identity.displayName, identity.teamGroupIds, users, groupUsers);
+	if (primary) return primary;
+	const primaryName = normalizedName(identity.displayName);
+	const alternateMatches = (identity.alternateNames ?? [])
+		.filter(name => normalizedName(name) !== primaryName)
+		.flatMap(name => {
+			const match = matchOpenProjectName(name, identity.teamGroupIds, users, groupUsers);
+			return match ? [match] : [];
+		});
+	const matchesByUser = new Map(alternateMatches.map(match => [match.user.id, match]));
+	return matchesByUser.size === 1 ? matchesByUser.values().next().value : undefined;
 }
 
 function teamGroupIds(member: GuildMember, config: IntegrationConfig) {
@@ -80,6 +99,7 @@ export async function resolveOpenProjectIdentity(
 	const match = matchOpenProjectIdentity({
 		id: member.id,
 		displayName: member.displayName,
+		alternateNames: [member.user.globalName, member.user.username].filter((name): name is string => Boolean(name)),
 		teamGroupIds: teamGroupIds(member, config),
 	}, users, groupUsers);
 	if (!match) return { problem: "ambiguous_or_unmapped" };
@@ -107,7 +127,12 @@ export async function reconcileOpenProjectUsers(
 	let ambiguous = 0;
 	for (const member of members.values()) {
 		if (member.user.bot || !member.roles.cache.has(config.ORGANIZER_GUILD_MEMBER_ROLE_ID) || existing.has(member.id)) continue;
-		const match = matchOpenProjectIdentity({ id: member.id, displayName: member.displayName, teamGroupIds: teamGroupIds(member, config) }, users, groupUsers);
+		const match = matchOpenProjectIdentity({
+			id: member.id,
+			displayName: member.displayName,
+			alternateNames: [member.user.globalName, member.user.username].filter((name): name is string => Boolean(name)),
+			teamGroupIds: teamGroupIds(member, config),
+		}, users, groupUsers);
 		if (!match || usedOpenProjectIds.has(match.user.id)) {
 			ambiguous++;
 			continue;

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -27,8 +27,25 @@ test("ambiguous first names are never linked automatically", () => {
 	assert.equal(matchOpenProjectIdentity({ id: "4", displayName: "Julie [Community]", teamGroupIds: [] }, users, groups)?.user.id, 180);
 });
 
+test("a unique alternate Discord name can resolve an ambiguous guild nickname", () => {
+	const ambiguousTeamGroups = new Map([[26, new Set([174, 178])]]);
+	const match = matchOpenProjectIdentity({
+		id: "5",
+		displayName: "Maria",
+		alternateNames: ["Maria K"],
+		teamGroupIds: [26],
+	}, users, ambiguousTeamGroups);
+	assert.deepEqual({ id: match?.user.id, reason: match?.reason }, { id: 174, reason: "last_initial" });
+	assert.equal(matchOpenProjectIdentity({
+		id: "6",
+		displayName: "Maria",
+		alternateNames: ["Maria K", "Maria M"],
+		teamGroupIds: [],
+	}, users, groups), undefined);
+});
+
 function member(id, displayName, roles = []) {
-	return { id, displayName, user: { bot: false }, roles: { cache: { has: role => roles.includes(role) } } };
+	return { id, displayName, user: { bot: false, globalName: null, username: displayName }, roles: { cache: { has: role => roles.includes(role) } } };
 }
 
 test("on-demand identity resolution uses an existing mapping without fetching Discord or OpenProject", async () => {


### PR DESCRIPTION
## Summary
- retain guild display names as the primary identity signal
- fall back to Discord global names and usernames only when the primary name is unresolved
- link only when all matching alternate names identify one OpenProject account

## Verification
- npm test: 247 passing
- git diff --check

## Production impact
This resolves one of the six current ambiguous identities without guessing. The other five lack authoritative distinguishing evidence and remain safely unlinked.